### PR TITLE
Fixed typo in Create ApiKeys and changed example request in Get Product

### DIFF
--- a/docs/Api-Keys/create-apikeys.md
+++ b/docs/Api-Keys/create-apikeys.md
@@ -39,7 +39,7 @@ Let's review the steps one more time.
 
 -   Find the settings menu item from the sidebar menu.
 -   Click the dropdown and select the advanced menu item.
--   On the page displayed, select 'generte api keys'.
+-   On the page displayed, select 'generate api keys'.
 -   Fill in the form by providing an app name (for identification), and access levels for the key.
 -   Click on 'generate', and then retrieve the keys generated for you.
 ```

--- a/docs/products/get-product.md
+++ b/docs/products/get-product.md
@@ -38,7 +38,7 @@ This is a protected endpoint so as part of the request, you need to send `Appid`
 ## Example Request
 
 ```bash
-curl -X GET "https://api.timbu.cloud/products?organization_id=123&reverse_sort=false&page=2&size=10&APP_ID=123&API_KEY=1234567890" 
+curl -X GET "https://api.timbu.cloud/products?organization_id=123&reverse_sort=false&page=2&size=10&Appid=123&Apikey=1234567890" 
 ```
 
 


### PR DESCRIPTION
Changes Made:

1.Create ApiKeys--  Fixed a typo: changed 'generte' to 'generate' for better clarity.

2.Get Product--  Updated the example request to use Appid instead of APP_ID and Apikey instead of API_KEY for consistency and accuracy.

These changes aim to improve the readability and accuracy of the API documentation.
